### PR TITLE
Issue #3: Fix Typos in Lecture #9

### DIFF
--- a/notes/lecture9/1-DataTypes.md
+++ b/notes/lecture9/1-DataTypes.md
@@ -27,7 +27,7 @@ echo "My name is $name, I live in $city";
 ```
 
 ### The concatenation operator `.`
-The concatenation operator is a special character in PHP `.` used to combine strings.
+The concatenation operator `.` is a special character in PHP used to combine strings.
 
 ```php
 echo 'Hello' . ' World!'; // concatenating string literals
@@ -52,7 +52,7 @@ echo 'My name is ' . $name . ', I am ' . $age . ' years old.';
 ```
 
 ## Integer
-A whole number without a decimal point, like 10. They can hold positive or negative values.
+A whole number without a decimal point, like `10`. They can hold positive or negative values.
 
 ```php
 $age = 26;
@@ -60,7 +60,7 @@ $student_loan_debt = -1000000;
 ```
 
 ## Floats
-A number with precision or with a decimal point: `3.14`. Floating-point numbers have limited precision.  These can be positive or negative in value.
+A number with precision or with a decimal point, like `3.14`. Floating-point numbers have limited precision.  These can be positive or negative in value.
 
 ```php
 $price = 10.77; // cheese pizza and a large soda from Panucci's pizza, same as my pin number
@@ -90,10 +90,10 @@ An array is a *data structure* that can store multiple values in a single variab
 
 *Note*: A data structure is a particular format for storing and organizing data.
 
-There are three different types of arrays in PHP, let's discuss two for now.
+There are three different types of arrays in PHP. Let's discuss two for now.
 
 ### Indexed Arrays
-Sometimes referred to as a numeric array, but this doesn’t mean that it only stores numbers. It means that the indices of the array are a number and values are stored and accessed in a linear manner. They can store anything like numbers, strings, etc.. The default array index starts at `0`.
+Sometimes referred to as a numeric array, but this doesn’t mean that it only stores numbers. It means that the indices of the array are numbers and values are stored and accessed in a linear manner. They can store anything like numbers, strings, etc. The default array index starts at `0`.
 
 ```php
 // this is how you declare and initialize an array

--- a/notes/lecture9/3-ComLogOps.md
+++ b/notes/lecture9/3-ComLogOps.md
@@ -7,7 +7,7 @@ Comparison operators compare two different values to equate to a TRUE or FALSE o
 ### `==` Equality operator
 **Not assignment**.  Checks if two values are equal.  This of it as "_is equal to_".
 
-```
+```php
 1 == 2 // FALSE. 1 does not equal 2
 1 == 1 // TRUE
 
@@ -22,14 +22,14 @@ $val1 == $val3 // TRUE
 ### `===` Identity operator
 Like the equality operator, but also checks if the two values are _of the same type_.
 
-```
+```php
 1 == '1' // FALSE. The integer 1 is not identical to the string "1"
 ```
 
 ### `>` Greater than
 Returns true if the value on the left is greater than the value on the right.
 
-```
+```php
 5 > 1 // TRUE
 1 > 5 // FALSE
 ```
@@ -37,7 +37,7 @@ Returns true if the value on the left is greater than the value on the right.
 ### `<` Less than
 Returns true if the value on the right is greater than the value on the left.
 
-```
+```php
 5 < 1 // FALSE
 1 < 5 // TRUE
 ```
@@ -80,7 +80,7 @@ Returns true if the values on the left and right are not identical.
 
 ## Logical Operators
 
-## `&&` And
+### `&&` And
 Returns TRUE if the value on the left _and_ the value on the right are
 TRUE.
 
@@ -95,9 +95,9 @@ $isCute && $isFunny // FALSE because one of the values is false
 $isCute && $isNice && $isFunny // FALSE because all of the values must be true
 ```
 
-## `||` Or
+### `||` Or
 Those two vertical lines are the pipe character on your keyboard. They
-must be typed without a space in between the two. Returns TRUE if the value on the left _or_ the value on the right are TRUE.
+must be typed without a space in between them. Returns TRUE if the value on the left _or_ the value on the right are TRUE.
 
 ```php
 $isCute = TRUE;
@@ -107,15 +107,15 @@ $isSmart = FALSE;
 
 $isCute || $isNice // TRUE because both of the values are true
 $isCute || $isFunny // TRUE because at least one of the values is true
-$isSmart || $isFunny // FALSE because none of the values are trues
+$isSmart || $isFunny // FALSE because none of the values are true
 
-$isCute || $isNice && $isFunny // FALSE because all of the values must be true
+$isCute || $isNice && $isFunny // FALSE because $isCute OR $isNIce must be true AND $isFunny must also be true
 ```
 
-## `!` Not
-Returns TRUE if a value is _not_ TRUE. It makes it the opposite of it’s current value.
+### `!` Not
+Returns TRUE if a value is _not_ TRUE. This makes it the opposite of its current value.
 
-```
+```php
 $isCute = TRUE;
 !$isCute; // FALSE
 
@@ -126,7 +126,7 @@ $isFunny = FALSE;
 !$isFunny; // TRUE
 
 $isSmart = FALSE;
-!$isSmart; // TRUE;
+!$isSmart; // TRUE
 ```
 
 

--- a/notes/lecture9/4-Conditionals.md
+++ b/notes/lecture9/4-Conditionals.md
@@ -3,20 +3,20 @@ Conditionals are a group of control structures in PHP. They help determine the f
 
 ## `if` Statement
 
-```
-if (expressionThatEvaluatesToBoolen) {
+```php
+if (expressionThatEvaluatesToBoolean) {
 	// statements to execute
 }
 ```
 
 In the example listed above, `if` is the keyword, everything inside of our opening and closing parenthesis is the Boolean expression that must evaluate to TRUE or FALSE. We accomplish this through a variety of comparison and/or logical operators ([reviewed in the previous section](3-ComLogOps.md)).
-Then start our code block with an opening curly brace. The opening curly brace starts a block of code. Include any statements that should be exectured after the opening curly brace.  Finally, to end the block of code we include the closing curly brace.  Let's take a look at a real `if` statement:
+Then start our code block with an opening curly brace. The opening curly brace starts a block of code. Include any statements that should be executed after the opening curly brace.  Finally, to end the block of code, we include the closing curly brace. Let's take a look at a real `if` statement:
 
 ```php
 $age = 21;
 
 if ($age >= 21) {
-	echo "You can legally Drink!";
+	echo "You can legally drink!";
 }
 ```
 
@@ -27,7 +27,7 @@ We can combine `if` statements with `else` statements in order to provide anothe
 $age = 20;
 
 if ($age >= 21) {
-	echo "You can legally Drink!";
+	echo "You can legally drink!";
 } else {
 	// this block of code is executed when the if statement is not executed
 	echo "Sorry, no beer for you :("
@@ -35,7 +35,7 @@ if ($age >= 21) {
 ```
 
 ## `elseif` statements
-In addition to `if` and `else` statements, we have `elseif` statements.  `elseif` is the combination of an `else` and and `if` statement.  This means if the previous condition was not met (`else`) _and_ if the current condition _is_ met, then the code block can be run
+In addition to `if` and `else` statements, we have `elseif` statements.  `elseif` is the combination of an `else` and and `if` statement.  This means if the previous condition was not met (`else`) _and_ if the current condition _is_ met, then the code block can be run.
 
 ```php
 $age = 20;
@@ -43,15 +43,15 @@ $citizen = false;
 
 if ($age >= 18 && $citizen) {
 	echo "You can legally vote!";
-} elseif ($age >= 18 && $citizen === FALSE) {
-	echo "Sorry, you must be a citizen to vote";
+} elseif ($age >= 18 && $citizen == FALSE) {
+	echo "Sorry, you must be a citizen to vote.";
 } else {
-	echo "Sorry, even though you are a citizen you must be 18 years old or over to vote";
+	echo "Sorry, even though you are a citizen, you must be 18 years old or over to vote.";
 }
 ```
 
 ## `switch` statements
-Similar to an if statement, a switch statement is used to perform different sets of actions based on the result of a condition. A switch statement is useful when you want to compare a variable or expression with many different values and then execute a particular piece of code that is associated with a specific value. *It is important to note that with a switch statement condition, we are testing for equality. We are not making a comparison or checking for a Boolean value*.
+Similar to an `if` statement, a `switch` statement is used to perform different sets of actions based on the result of a condition. A `switch` statement is useful when you want to compare a variable or expression with many different values and then execute a particular piece of code that is associated with a specific value. *It is important to note that with a `switch` statement condition, we are testing for equality. We are not making a comparison or checking for a Boolean value*.
 
 The basic format of a `switch` statement looks like the following:
 
@@ -77,10 +77,10 @@ switch (value) {
 
 The important keywords are
 
-1. `switch` indicating that we are beginning our switch statement.  The `switch` command evaluates the expression in the set of parenthesis, followed by the open and close curly braces that contain the conditional cases.
-2. `case` The value of the expression/variable (`value`) is compared to the value of each `case`.  If a `case` matches, the code that corresponds to it will be executed.
-3. `break` let's our `switch` statement know when to finish executing the statements of the `case` that was run.  Make sure to end your `case` statements with the `break` keyword!  Without `break`, your code will continue to run to the next case statement block as well.
-4. `default` (optional) if none of the cases are a match, then we can include a `default` case to be executed instead.
+1. `switch`: Indicating that we are beginning our `switch` statement. The `switch` command evaluates the expression in the set of parenthesis, followed by the open and close curly braces that contain the conditional cases.
+2. `case`: The value of the expression / variable (`value`) is compared to the value of each `case`. If a `case` matches, the code that corresponds to it will be executed.
+3. `break`: Lets our `switch` statement know when to finish executing the statements of the `case` that was run. Make sure to end your `case` statements with the `break` keyword! Without `break`, your code will continue to run to the next case statement block as well.
+4. `default` (optional): If none of the cases are a match, then we can include a `default` case to be executed instead.
 
 ```php
 $animal = 'dog';
@@ -95,13 +95,12 @@ switch ($animal) {
 		break;
 
 	case 'porcupine':
-		echo "A group of porcupine is called a prickle";
+		echo "A group of porcupines is called a prickle";
 		break;
 
 	case 'hyena':
 		echo "A group of hyenas is called a cackle";
 		break;
-
 
 	default:
 		echo "A group of animals is called Rose Hill Students";
@@ -116,5 +115,3 @@ switch ($animal) {
 ___
 
 [« Back - Logical Operators](3-ComLogOps.md)
-
-

--- a/notes/lecture9/README.md
+++ b/notes/lecture9/README.md
@@ -3,8 +3,8 @@ This lecture focuses on the programming features of the PHP language including d
 
 ## Table of Contents
 - [1. Data Types](1-DataTypes.md)
-- [2. Operators](1-Operators.md)
-- [3. Comparison and Logical Operators](3-Operators.md)
+- [2. Operators](2-Operators.md)
+- [3. Comparison and Logical Operators](3-ComLogOps.md)
 - [4. Conditional Statements](4-Conditionals.md)
 
 ## Resources
@@ -18,5 +18,3 @@ This lecture focuses on the programming features of the PHP language including d
 - Chapter 2.6.9: [Case Switching](http://www.hackingwithphp.com/2/6/9/case-switching)
 - Chapter 3: [Simple Variables and Operators](http://www.hackingwithphp.com/3/0/0/simple-variables-and-operators)
 - Chapter 5: [Arrays](http://www.hackingwithphp.com/5/0/0/arrays)
-
-


### PR DESCRIPTION
This pull request takes care of **[Issue #3](https://github.com/yurm04/CISC2350/issues/3)** by correction some typos in the **[notes files for lecture #9](https://github.com/yurm04/CISC2350/tree/master/notes/lecture9). This includes:
- fixing the navigation links in README.md,
- specifying code snippets as PHP for some of the sample codes,
- correcting spelling mistakes, such as "Boolen" to "Boolean" and "exectured" to "executed",
- removing unnecessary apostrophes, such as "let's" to "lets" and "it's" to "its", and
- making other minor typographical and stylistic improvements.

@yurm04